### PR TITLE
ci(docker): build multi-arch (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,18 +2,32 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches: [ "main" ] # Déclenche l'action quand tu push sur la branche main
+    branches: [ "main", "ci/arm-multiarch" ]
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Plateformes à builder (séparées par des virgules)"
+        required: false
+        default: "linux/amd64,linux/arm64"
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write # Autorise l'écriture sur le registre d'images
+      packages: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -27,5 +41,7 @@ jobs:
         with:
           context: .
           push: true
-          # Remplace "knaox" par ton pseudo GitHub exact s'il est différent (tout en minuscules !)
+          platforms: ${{ github.event.inputs.platforms || 'linux/amd64,linux/arm64' }}
           tags: ghcr.io/knaox/tentacle-tv:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,15 +4,25 @@ on:
   push:
     branches: [ "main", "ci/arm-multiarch" ]
   workflow_dispatch:
-    inputs:
-      platforms:
-        description: "Plateformes à builder (séparées par des virgules)"
-        required: false
-        default: "linux/amd64,linux/arm64"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: knaox/tentacle-tv
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -21,10 +31,53 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
         with:
-          platforms: arm64
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -32,16 +85,17 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          platforms: ${{ github.event.inputs.platforms || 'linux/amd64,linux/arm64' }}
-          tags: ghcr.io/knaox/tentacle-tv:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary
- Ajoute le support **linux/arm64** au build Docker (en plus de **linux/amd64**)
- Setup **QEMU** + **Buildx** pour cross-compilation
- Ajout d'un trigger **workflow_dispatch** (lancement manuel)
- Cache **GitHub Actions** (`type=gha`) pour accélérer les builds suivants
- La branche `ci/arm-multiarch` est temporairement dans le trigger `push` pour valider le build avant merge — à retirer ensuite si souhaité

## Test plan
- [x] Workflow déclenché sur le push de la branche
- [ ] Build amd64 OK
- [ ] Build arm64 OK
- [ ] Image manifest contient les 2 architectures (`docker buildx imagetools inspect ghcr.io/knaox/tentacle-tv:latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)