### PR TITLE
fix(linux): crash lecture (GStreamer manquant) + fix EGL + sous-titres ASS

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -19,11 +19,13 @@
 # nom de la Release. Sans suffixe « -<build> » (linux-v1.9.9), la version du tag
 # est tout de même appliquée.
 #
-# Lecteur vidéo : libmpv est chargé au runtime par tauri-plugin-libmpv.
-#   • .deb / .rpm déclarent la dépendance (libmpv2 / mpv-libs) → installée par le
-#     gestionnaire de paquets (voir bundle.linux.* dans tauri.conf.json).
-#   • AppImage : l'utilisateur doit avoir « mpv »/« libmpv » installé (paquet
-#     présent par défaut sur la plupart des distros multimédia).
+# Lecteur vidéo : libmpv est chargé au runtime par tauri-plugin-libmpv. WebKitGTK
+# a AUSSI besoin des plugins GStreamer (autoaudiosink) — sans eux, l'app crashe au
+# lancement d'une lecture (WebKitWebProcess abort sur GStreamer / libEGL).
+#   • .deb / .rpm déclarent les dépendances (libmpv + gstreamer1.0-plugins-good…)
+#     → installées par le gestionnaire de paquets (voir bundle.linux.* dans
+#     tauri.conf.json). Le PKGBUILD pacman déclare mpv + gst-plugins-good.
+#   • AppImage : l'utilisateur doit avoir « mpv » + « gst-plugins-good » installés.
 #
 # Runner : ubuntu-22.04 (glibc/webkit plus anciens = paquets compatibles avec un
 # parc de distros plus large qu'ubuntu-latest/24.04).
@@ -141,11 +143,13 @@ jobs:
             - **Debian/Ubuntu** : `sudo apt install ./Tentacle.TV_*.deb`
             - **Fedora** : `sudo dnf install ./Tentacle.TV-*.rpm`
             - **Arch (pacman)** : `sudo pacman -U ./tentacle-tv-*.pkg.tar.zst`
-            - **AppImage (universel)** : `sudo pacman -S mpv fuse2 && chmod +x Tentacle.TV_*.AppImage && ./Tentacle.TV_*.AppImage`
+            - **AppImage (universel)** : `sudo pacman -S mpv fuse2 gst-plugins-good gst-libav && chmod +x Tentacle.TV_*.AppImage && ./Tentacle.TV_*.AppImage`
 
             ## Pré-requis lecteur vidéo
-            Le `.deb`/`.rpm` installe automatiquement **libmpv**. Pour l'AppImage,
-            installez-le au besoin : `sudo pacman -S mpv` (Arch) ou l'équivalent.
+            Le `.deb`/`.rpm` installe automatiquement **libmpv** + les plugins
+            **GStreamer** requis par WebKitGTK (sinon crash au lancement d'une
+            lecture). Pour l'AppImage : installez `mpv fuse2 gst-plugins-good
+            gst-libav` (Arch) ou l'équivalent Debian/Fedora.
           files: |
             dist-linux/*.deb
             dist-linux/*.rpm
@@ -202,7 +206,7 @@ jobs:
           arch=('x86_64')
           url="https://github.com/Knaox/Tentacle-TV"
           license=('MIT')
-          depends=('webkit2gtk-4.1' 'gtk3' 'mpv')
+          depends=('webkit2gtk-4.1' 'gtk3' 'mpv' 'gst-plugins-good' 'gst-plugins-base' 'gst-libav')
           options=('!strip' '!debug')
           package() {
             cp -a "\${startdir}/pkgroot/usr" "\${pkgdir}/usr"

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -16,6 +16,12 @@ mod audio_session;
 mod macos;
 
 fn main() {
+    // Linux (WebKitGTK) : le renderer DMABUF/EGL de WebKit entre en conflit avec
+    // le contexte GPU de mpv (vo=gpu-next) → crash aléatoire du WebKitWebProcess
+    // sur libEGL au lancement d'une lecture. On force le chemin de rendu compatible.
+    #[cfg(target_os = "linux")]
+    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+
     // Pas de tauri-plugin-updater : macOS est distribué via le Mac App Store
     // (MAJ gérées par l'App Store) et Windows via le Microsoft Store (MSIX).
     let mut builder = tauri::Builder::default()

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -54,10 +54,10 @@
     },
     "linux": {
       "deb": {
-        "depends": ["libmpv2 | libmpv1", "libwebkit2gtk-4.1-0", "libgtk-3-0"]
+        "depends": ["libmpv2 | libmpv1", "libwebkit2gtk-4.1-0", "libgtk-3-0", "gstreamer1.0-plugins-good", "gstreamer1.0-plugins-base", "gstreamer1.0-libav"]
       },
       "rpm": {
-        "depends": ["mpv-libs", "webkit2gtk4.1", "gtk3"]
+        "depends": ["mpv-libs", "webkit2gtk4.1", "gtk3", "gstreamer1-plugins-good", "gstreamer1-plugins-base", "gstreamer1-libav"]
       }
     }
   }

--- a/apps/web/src/components/player/mpvTrackMapping.ts
+++ b/apps/web/src/components/player/mpvTrackMapping.ts
@@ -30,12 +30,14 @@ export function langMatch(a?: string, b?: string): boolean {
   return (LANG_NORM[a] ?? a) === (LANG_NORM[b] ?? b);
 }
 
-/** Get the best subtitle delivery format for mpv based on codec. */
+/** Get the best subtitle delivery format for mpv based on codec.
+ *  Défaut = "ass" : demander un sous-titre à Jellyfin en .srt convertit une source
+ *  ASS en laissant les balises de positionnement {\an8} en clair (bug d'affichage
+ *  sous Linux/libmpv). L'ASS préserve le positionnement — libass interprète {\an8}. */
 export function nativeSubFormat(codec?: string): string {
   switch (codec?.toLowerCase()) {
-    case "ass": case "ssa": return "ass";
     case "srt": case "subrip": return "srt";
-    default: return "srt";
+    default: return "ass"; // ass, ssa, ou codec non reconnu
   }
 }
 


### PR DESCRIPTION
## Contexte
Le lecteur desktop **Linux** crashait aléatoirement au lancement d'une lecture (`WebKitWebProcess` abort). Diagnostiqué et reproduit sur une VM Arch Linux (banc de test).

## Cause
1. **Plugins GStreamer manquants** — WebKitGTK utilise GStreamer pour ses éléments média HTML5. `autoaudiosink` (fourni par `gst-plugins-good`, un *optdepend* de webkit2gtk **non tiré automatiquement**) était absent → `g_signal_connect` sur un objet NULL → `abort()`.
2. **Contention EGL** — le renderer DMABUF de WebKit entrait en conflit avec le contexte GPU de mpv (`vo=gpu-next`) → crash sur `libEGL_mesa`.
3. **Sous-titres `{\an8}`** — les sous-titres ASS externes étaient demandés à Jellyfin en `.srt` ; la conversion ASS→SRT laisse les balises de positionnement `{\an8}` en clair.

## Correctifs
- **`.github/workflows/release-linux.yml`** (PKGBUILD pacman) : `depends` += `gst-plugins-good gst-plugins-base gst-libav`
- **`tauri.conf.json`** (deb/rpm) : `depends` += plugins GStreamer équivalents
- **`main.rs`** : `WEBKIT_DISABLE_DMABUF_RENDERER=1` sous Linux
- **`mpvTrackMapping.ts`** : `nativeSubFormat` défaut → `ass`
- Doc AppImage : installer `gst-plugins-good` / `gst-libav`

## À valider
- CI Linux (build deb/rpm/appimage + repackage pacman) verte
- Lecture + sous-titres sur une vraie machine Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)
